### PR TITLE
Adding error reporting for faulty data in decoding

### DIFF
--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -69,6 +69,9 @@ defmodule Bencode.Decoder do
   defp do_decode(%__MODULE__{rest: <<char, _::binary>>, position: position}) do
     {:error, "Unexpected character at #{position}, expected a string; an integer; a list; or a dictionary, got: #{char}"}
   end
+  # handle empty strings
+  defp do_decode(%__MODULE__{rest: <<>>} = state),
+    do: state
 
   #=integers -----------------------------------------------------------
   defp decode_integer(%__MODULE__{rest: <<"e", rest::binary>>} = state, acc) when length(acc) > 0 do

--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -67,7 +67,7 @@ defmodule Bencode.Decoder do
     decode_string(state, [])
   end
   defp do_decode(%__MODULE__{rest: <<char, _::binary>>, position: position}) do
-    {:error, "Unexpected character #{char} at #{position}, expected a string; an integer; a list; or a dictionary"}
+    {:error, "Unexpected character at #{position}, expected a string; an integer; a list; or a dictionary, got: #{char}"}
   end
 
   #=integers -----------------------------------------------------------
@@ -84,7 +84,7 @@ defmodule Bencode.Decoder do
   defp decode_integer(%__MODULE__{rest: <<"e", _::binary>>} = state, []),
     do: {:error, "Empty integer starting at #{state.position - 1}"}
   defp decode_integer(%__MODULE__{rest: <<char, _::binary>>, position: position}, _),
-    do: {:error, "Unexpected character at #{position}, expected a number or an `e` but got #{char}"}
+    do: {:error, "Unexpected character at #{position}, expected a number or an `e`, got: #{char}"}
 
   #=strings ------------------------------------------------------------
   defp decode_string(%__MODULE__{rest: <<":", data::binary>>} = state, acc) do
@@ -108,7 +108,7 @@ defmodule Bencode.Decoder do
     decode_string(new_state, [number|acc])
   end
   defp decode_string(%__MODULE__{rest: <<char, _::binary>>, position: position}, _) do
-    {:error, "Unexpected character at #{position}, expected a number or an `:` but got #{char}"}
+    {:error, "Unexpected character at #{position}, expected a number or an `:`, got: #{char}"}
   end
 
   #=lists --------------------------------------------------------------
@@ -129,7 +129,7 @@ defmodule Bencode.Decoder do
   end
   # errors
   defp decode_list(%__MODULE__{rest: <<>>, position: position}, _) do
-    {:error, "Unexpected character at #{position}, expected data or an end character but got end of data"}
+    {:error, "Unexpected character at #{position}, expected data or an end character, got end of data"}
   end
 
   #=dictionaries -------------------------------------------------------
@@ -145,7 +145,7 @@ defmodule Bencode.Decoder do
   end
   # errors
   defp decode_dictionary(%__MODULE__{rest: <<>>, position: position}, _) do
-    {:error, "Unexpected character at #{position}, expected data or an end character but got end of data"}
+    {:error, "Unexpected character at #{position}, expected data or an end character, got end of data"}
   end
 
   #=helpers ============================================================

--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -118,13 +118,18 @@ defmodule Bencode.Decoder do
             rest: rest,
             data: acc |> Enum.reverse}
   end
-  defp decode_list(%__MODULE__{rest: data} = state, acc) do
-    {item, rest, position} =
-      case do_decode(%__MODULE__{state|rest: data}) do
-        %__MODULE__{data: data, rest: rest, position: position} ->
-          {data, rest, position}
-      end
-    decode_list(%__MODULE__{state|rest: rest, position: position}, [item|acc])
+  defp decode_list(%__MODULE__{rest: data} = state, acc) when data != "" do
+    case do_decode(%__MODULE__{state|rest: data}) do
+      %__MODULE__{data: data, rest: rest, position: position} ->
+        decode_list(%__MODULE__{state|rest: rest, position: position}, [data|acc])
+
+      {:error, _} = error ->
+        error
+    end
+  end
+  # errors
+  defp decode_list(%__MODULE__{rest: <<>>, position: position}, _) do
+    {:error, "Unexpected character at #{position}, expected data or an end character but got end of data"}
   end
 
   #=dictionaries -------------------------------------------------------

--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -12,6 +12,9 @@ defmodule Bencode.Decoder do
       %__MODULE__{data: data, rest: ""} ->
         {:ok, data}
 
+      %__MODULE__{rest: <<char, _::binary>>, position: position} ->
+        {:error, "Unexpected character at #{position}, expected no more data, got: #{char}"}
+
       {:error, _} = error ->
         error
     end
@@ -21,6 +24,9 @@ defmodule Bencode.Decoder do
     case do_decode(%__MODULE__{rest: data, opts: %{calculate_info_hash: true}}) do
       %__MODULE__{data: data, rest: "", checksum: checksum} ->
         {:ok, data, checksum}
+
+      %__MODULE__{rest: <<char, _::binary>>, position: position} ->
+        {:error, "Unexpected character at #{position}, expected no more data, got: #{char}"}
 
       {:error, _} = error ->
         error

--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -66,8 +66,8 @@ defmodule Bencode.Decoder do
   defp do_decode(%__MODULE__{rest: <<first, _::binary>>} = state) when first in ?0..?9 do
     decode_string(state, [])
   end
-  defp do_decode(%__MODULE__{rest: <<token, _::binary>>, position: position}) do
-    {:error, "unexpected token #{token} at #{position}"}
+  defp do_decode(%__MODULE__{rest: <<char, _::binary>>, position: position}) do
+    {:error, "Unexpected character #{char} at #{position}, expected a string; an integer; a list; or a dictionary"}
   end
 
   #=integers -----------------------------------------------------------
@@ -81,9 +81,9 @@ defmodule Bencode.Decoder do
     new_state = %__MODULE__{state|position: state.position + 1, rest: rest}
     decode_integer(new_state, [current|acc])
   end
-  defp decode_integer(%__MODULE__{rest: <<token, _::binary>>, position: position}, _) do
-    {:error, "Unexpected token at #{position}, expected a number or an `e` but got #{token}"}
-  end
+  # errors
+  defp decode_integer(%__MODULE__{rest: <<char, _::binary>>, position: position}, _),
+    do: {:error, "Unexpected character at #{position}, expected a number or an `e` but got #{char}"}
 
   #=strings ------------------------------------------------------------
   defp decode_string(%__MODULE__{rest: <<":", data::binary>>} = state, acc) do
@@ -106,8 +106,8 @@ defmodule Bencode.Decoder do
               rest: rest}
     decode_string(new_state, [number|acc])
   end
-  defp decode_string(%__MODULE__{rest: <<token, _::binary>>, position: position}, _) do
-    {:error, "Unexpected token at #{position}, expected a number or an `:` but got #{token}"}
+  defp decode_string(%__MODULE__{rest: <<char, _::binary>>, position: position}, _) do
+    {:error, "Unexpected character at #{position}, expected a number or an `:` but got #{char}"}
   end
 
   #=lists --------------------------------------------------------------

--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -71,17 +71,18 @@ defmodule Bencode.Decoder do
   end
 
   #=integers -----------------------------------------------------------
-  defp decode_integer(%__MODULE__{rest: <<"e", rest::binary>>} = state, acc) do
+  defp decode_integer(%__MODULE__{rest: <<"e", rest::binary>>} = state, acc) when length(acc) > 0 do
     %__MODULE__{state|position: state.position + 1,
                       rest: rest,
                       data: prepare_integer(acc)}
   end
-  defp decode_integer(%__MODULE__{rest: <<current, rest::binary>>} = state, acc)
-  when current == ?- or current in ?0..?9 do
+  defp decode_integer(%__MODULE__{rest: <<current, rest::binary>>} = state, acc) when current == ?- or current in ?0..?9 do
     new_state = %__MODULE__{state|position: state.position + 1, rest: rest}
     decode_integer(new_state, [current|acc])
   end
   # errors
+  defp decode_integer(%__MODULE__{rest: <<"e", _::binary>>} = state, []),
+    do: {:error, "Empty integer starting at #{state.position - 1}"}
   defp decode_integer(%__MODULE__{rest: <<char, _::binary>>, position: position}, _),
     do: {:error, "Unexpected character at #{position}, expected a number or an `e` but got #{char}"}
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bencode.Mixfile do
   def project do
     [app: :bencode,
      version: "0.0.2",
-     elixir: "~> 1.1",
+     elixir: "~> 1.2.0-rc",
      test_pattern: "*_{test,eqc}.exs",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/bencode_eqc.exs
+++ b/test/bencode_eqc.exs
@@ -1,5 +1,5 @@
 defmodule BencodeEQC do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use EQC.ExUnit
 
   # numbers

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -9,11 +9,14 @@ defmodule BencodeTest do
     assert checksum == <<109, 34, 98, 18, 111, 235, 110, 199, 189, 52, 100, 147, 80, 37, 200, 198, 9, 192, 17, 157>>
   end
 
-  test "returning error tuples on faulty input" do
+  test "returning error tuples on faulty input containing only integers" do
     # unexpected character
     {:error, reason} = Bencode.decode("i1be")
     assert reason =~ "character at 2"
 
+    {:error, reason} = Bencode.decode("ie")
+    assert reason =~ "Empty integer"
+    assert reason =~ "starting at 0"
   end
 
   test "returning error tuples on faulty input containing only strings" do

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -1,5 +1,5 @@
 defmodule BencodeTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Bencode
 
   test "calculate checksum of info directory when decoding" do

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -60,4 +60,8 @@ defmodule BencodeTest do
     {:error, reason} = Bencode.decode("e")
     assert reason =~ "Unexpected character at 0"
   end
+
+  test "empty data should return nil" do
+    assert {:ok, nil} = Bencode.decode("")
+  end
 end

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -25,4 +25,14 @@ defmodule BencodeTest do
     assert reason =~ "at 2 "
     assert reason =~ "out of bounds"
   end
+
+  test "returning error tuples on faulty input containing lists with integers" do
+    {:error, reason} = Bencode.decode("li28e") # missing `e` at end of data
+    assert reason =~ "character at 5,"
+    assert reason =~ "end of data"
+
+    {:error, reason} = Bencode.decode("li42eiee")
+    assert reason =~ "Empty integer"
+    assert reason =~ "starting at 5"
+  end
 end

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -55,4 +55,9 @@ defmodule BencodeTest do
     assert reason =~ "Unexpected character"
     assert reason =~ "at 4"
   end
+
+  test "faulty data at top level" do
+    {:error, reason} = Bencode.decode("e")
+    assert reason =~ "Unexpected character at 0"
+  end
 end

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -59,6 +59,10 @@ defmodule BencodeTest do
   test "faulty data at top level" do
     {:error, reason} = Bencode.decode("e")
     assert reason =~ "Unexpected character at 0"
+
+    {:error, reason} = Bencode.decode("i1ei2e")
+    assert reason =~ "Unexpected character"
+    assert reason =~ "expected no more data"
   end
 
   test "empty data should return nil" do

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -10,9 +10,14 @@ defmodule BencodeTest do
   end
 
   test "returning error tuples on faulty input" do
+    # unexpected character
     {:error, reason} = Bencode.decode("i1be")
-    assert reason =~ "token at 2"
+    assert reason =~ "character at 2"
 
+  end
+
+  test "returning error tuples on faulty input containing only strings" do
+    # too short of a string
     {:error, reason} = Bencode.decode("3:fo")
     assert reason =~ "at 2 "
     assert reason =~ "out of bounds"

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -8,4 +8,13 @@ defmodule BencodeTest do
     assert data == input
     assert checksum == <<109, 34, 98, 18, 111, 235, 110, 199, 189, 52, 100, 147, 80, 37, 200, 198, 9, 192, 17, 157>>
   end
+
+  test "returning error tuples on faulty input" do
+    {:error, reason} = Bencode.decode("i1be")
+    assert reason =~ "token at 2"
+
+    {:error, reason} = Bencode.decode("3:fo")
+    assert reason =~ "at 2 "
+    assert reason =~ "out of bounds"
+  end
 end

--- a/test/bencode_test.exs
+++ b/test/bencode_test.exs
@@ -35,4 +35,24 @@ defmodule BencodeTest do
     assert reason =~ "Empty integer"
     assert reason =~ "starting at 5"
   end
+
+  test "returning error tuples on faulty input containing dictionaries with integers" do
+    {:error, reason} = Bencode.decode("d3:fooi28e") # missing `e` at end of data
+    assert reason =~ "character at 10,"
+    assert reason =~ "end of data"
+
+    {:error, reason} = Bencode.decode("d3:fooiee") # empty integer as value
+    assert reason =~ "Empty integer"
+    assert reason =~ "at 6"
+  end
+
+  test "returning error tuples on faulty input containing dictionaries with strings" do
+    {:error, reason} = Bencode.decode("d3:foo2:bare") # too short of a string as value
+    assert reason =~ "Unexpected character"
+    assert reason =~ "at 10"
+
+    {:error, reason} = Bencode.decode("d1:foo2:bare") # faulty string as key
+    assert reason =~ "Unexpected character"
+    assert reason =~ "at 4"
+  end
 end


### PR DESCRIPTION
- Strings should complain if they are longer than the remaining data
- String also complain if other stuff than numbers are consumed before the `:` character
- Numbers should complain if they contain other stuff than numbers or end characters
- Handling empty integers (`ie`), returning error
- Non-finished lists throws an error too `li13e`
- Errors occurring when parsing dictionaries should get reported too
- Empty input to the decoder should now return {:ok, nil}
- If there are remaining data when the decoder reach the end it will get reported as faulty b-code
