### PR TITLE
implement `decode_with_info_hash!` function

### DIFF
--- a/lib/bencode.ex
+++ b/lib/bencode.ex
@@ -25,4 +25,7 @@ defmodule Bencode do
 
   defdelegate decode_with_info_hash(data),
     to: Bencode.Decoder
+
+  defdelegate decode_with_info_hash!(data),
+    to: Bencode.Decoder
 end

--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -53,6 +53,16 @@ defmodule Bencode.Decoder do
     end
   end
 
+  @spec decode_with_info_hash!(binary) :: {encodable, <<_::20 * 8>> | nil} | no_return
+  def decode_with_info_hash!(data) do
+    case decode_with_info_hash(data) do
+      {:ok, data, checksum} ->
+        {data, checksum}
+      {:error, reason} = error ->
+        raise Error, reason: reason, action: "decode data", data: data
+    end
+  end
+
   # handle integers
   defp do_decode(%State{rest: <<"i", data::binary>>} = state) do
     %State{state|rest: data}


### PR DESCRIPTION
Hi,

Changed parse_torrent bencoding library to bencode.

I would like to use the bang version of this method,
so  I don't have to check for error tuple in
my `parse!` bang method, and raise there, I just let 
Bencode raise.

What do you think?
