### PR TITLE
Docs & formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ erl_crash.dump
 *.ez
 *.eqc-info
 *.eqc
+/doc/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The decoder should handle malformed data, either by raising an error, or returni
 
 * `Bencode.decode/1` will decode a b-code encoded string and return a 2-tuple; containing the status (`:ok`) and its Elixir data structure representation. Should the data be invalid a 2-tuple will get returned with `{:error, reason}`
 
-* `Bencode.decode!/1` will decode a b-code encoded string and return the decoded result as a Elixir data structure; if the input is invalid an it will raise with the reason.
+* `Bencode.decode!/1` will decode a b-code encoded string and return the decoded result as an Elixir data structure; if the input is invalid it will raise with the reason.
 
 * `Bencode.decode_with_info_hash/1` will decode a b-code encoded string and return a 3-tuple; containing the status (`:ok`), its Elixir data structure representation along with the checksum of the info dictionary. If no info-dictionary was found the last value will be `nil`. `{:error, reason}` will get returned if the input data was invalid b-code.
 

--- a/lib/bencode.ex
+++ b/lib/bencode.ex
@@ -1,6 +1,12 @@
 defmodule Bencode do
   @type encodable :: binary | atom | Map | List | Integer
 
+  @doc """
+  Encode a given data structure to the b-code representation and
+  return a `{:ok, data}`-tuple on success.
+
+  Returns an `{:error, reason}`-tuple if the data was invalid.
+  """
   @spec encode(encodable) :: {:ok, binary} | {:error, binary}
   def encode(data) do
     try do

--- a/lib/bencode.ex
+++ b/lib/bencode.ex
@@ -15,7 +15,7 @@ defmodule Bencode do
       {:ok, result}
     rescue
       e in Protocol.UndefinedError ->
-        {:error, "protocol Bencode.Encoder is not implemented for #{inspect e.value}"}
+        {:error, "protocol Bencode.Encoder is not implemented for #{inspect(e.value)}"}
     end
   end
 

--- a/lib/bencode.ex
+++ b/lib/bencode.ex
@@ -4,13 +4,12 @@ defmodule Bencode do
   @spec encode(encodable) :: {:ok, binary} | {:error, binary}
   def encode(data) do
     try do
-      Bencode.Encoder.encode!(data)
+      result = Bencode.Encoder.encode!(data)
+
+      {:ok, result}
     rescue
       e in Protocol.UndefinedError ->
         {:error, "protocol Bencode.Encoder is not implemented for #{inspect e.value}"}
-    else
-      result ->
-        {:ok, result}
     end
   end
 

--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -1,7 +1,6 @@
 defmodule Bencode.Decoder do
   @type encodable :: binary | atom | Map | List | Integer
 
-  @moduledoc false
   alias Bencode.Decoder.Error
   alias Bencode.Decoder.Options
 

--- a/lib/bencode/decoder.ex
+++ b/lib/bencode/decoder.ex
@@ -21,6 +21,12 @@ defmodule Bencode.Decoder do
   )
   alias Bencode.Decoder, as: State
 
+  @doc """
+  Decode a b-code encoded string and return a 2-tuple;
+  containing the status (`:ok`) and its Elixir data structure representation.
+
+  Should the data be invalid a 2-tuple will get returned with `{:error, reason}`
+  """
   @spec decode(binary) :: {:ok, encodable} | {:error, binary}
   def decode(data) do
     case do_decode(%State{rest: data}) do
@@ -35,6 +41,12 @@ defmodule Bencode.Decoder do
     end
   end
 
+  @doc """
+  Decode a b-code encoded string and return the decoded result
+  as an Elixir data structure.
+
+  If the input is invalid an it will raise with the reason.
+  """
   @spec decode!(binary) :: encodable | no_return
   def decode!(data) do
     case decode(data) do
@@ -46,6 +58,14 @@ defmodule Bencode.Decoder do
     end
   end
 
+  @doc """
+  Decode a b-code encoded string and return a 3-tuple;
+  containing the status (`:ok`), its Elixir data structure representation along
+  with the checksum of the info dictionary.
+
+  If no info-dictionary was found the last value will be `nil`.
+  `{:error, reason}` will get returned if the input data was invalid b-code.
+  """
   @spec decode_with_info_hash(binary) :: {:ok, encodable, binary | nil} | {:error, binary}
   def decode_with_info_hash(data) do
     case do_decode(%State{rest: data, opts: %Options{calculate_info_hash: true}}) do
@@ -60,6 +80,10 @@ defmodule Bencode.Decoder do
     end
   end
 
+  @doc """
+  Same as the `Bencode.decode_with_info_hash/1` function,
+  but will raise if the given input is malformed.
+  """
   @spec decode_with_info_hash!(binary) :: {encodable, binary | nil} | no_return
   def decode_with_info_hash!(data) do
     case decode_with_info_hash(data) do

--- a/lib/bencode/decoder/options.ex
+++ b/lib/bencode/decoder/options.ex
@@ -13,10 +13,6 @@ defmodule Bencode.Decoder.Options do
 
   """
 
-  @opaque t :: %Bencode.Decoder.Options{
-    calculate_info_hash: boolean
-  }
-  defstruct(
-    calculate_info_hash: false
-  )
+  @opaque t :: %Bencode.Decoder.Options{calculate_info_hash: boolean}
+  defstruct(calculate_info_hash: false)
 end

--- a/lib/bencode/encoder.ex
+++ b/lib/bencode/encoder.ex
@@ -1,6 +1,10 @@
 defprotocol Bencode.Encoder do
   @type encodable :: binary | atom | Map | List | Integer
 
+  @doc """
+  Encode a given data structure to the b-code representation;
+  it will raise an error if the given input is invalid.
+  """
   @spec encode!(encodable) :: binary | no_return
   def encode!(data)
 end

--- a/lib/bencode/encoder.ex
+++ b/lib/bencode/encoder.ex
@@ -21,7 +21,7 @@ end
 
 defimpl Bencode.Encoder, for: BitString do
   def encode!(string),
-    do: "#{byte_size string}:#{string}"
+    do: "#{byte_size(string)}:#{string}"
 end
 
 defimpl Bencode.Encoder, for: List do
@@ -34,10 +34,10 @@ defimpl Bencode.Encoder, for: Map do
     do: "d#{Enum.map_join(data, &encode_pair/1)}e"
 
   defp encode_pair({key, value}) when is_bitstring(key),
-    do: "#{Bencode.Encoder.encode! key}#{Bencode.Encoder.encode! value}"
+    do: "#{Bencode.Encoder.encode!(key)}#{Bencode.Encoder.encode!(value)}"
 
   defp encode_pair({key, value}) when is_atom(key) do
-    key_string = Atom.to_string key
-    "#{Bencode.Encoder.encode! key_string}#{Bencode.Encoder.encode! value}"
+    key_string = Atom.to_string(key)
+    "#{Bencode.Encoder.encode!(key_string)}#{Bencode.Encoder.encode!(value)}"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Bencode.Mixfile do
   defp deps do
     [
       {:eqc_ex, "~> 1.3.0"},
-      {:ex_doc, "~> 0.18.0", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.19", only: :dev, runtime: false}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,16 +4,18 @@ defmodule Bencode.Mixfile do
   @version "0.3.2"
 
   def project do
-    [app: :bencode,
-     version: @version,
-     elixir: "~> 1.2",
-     test_pattern: "*_{test,eqc}.exs",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps(),
-     docs: docs()]
+    [
+      app: :bencode,
+      version: @version,
+      elixir: "~> 1.2",
+      test_pattern: "*_{test,eqc}.exs",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      docs: docs()
+    ]
   end
 
   def application do
@@ -31,18 +33,22 @@ defmodule Bencode.Mixfile do
   end
 
   def package do
-    [files: ["lib", "mix.exs", "README*", "LICENSE"],
-     maintainers: ["Martin Gausby"],
-     licenses: ["Apache 2.0"],
-     links: %{"GitHub" => "https://github.com/gausby/bencode",
-              "Issues" => "https://github.com/gausby/bencode/issues",
-              "Contributors" => "https://github.com/gausby/bencode/graphs/contributors"}]
+    [
+      files: ["lib", "mix.exs", "README*", "LICENSE"],
+      maintainers: ["Martin Gausby"],
+      licenses: ["Apache 2.0"],
+      links: %{
+        "GitHub" => "https://github.com/gausby/bencode",
+        "Issues" => "https://github.com/gausby/bencode/issues",
+        "Contributors" => "https://github.com/gausby/bencode/graphs/contributors"
+      }
+    ]
   end
 
   defp deps do
     [
       {:eqc_ex, "~> 1.3.0"},
-      {:ex_doc, "~> 0.18.0", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.18.0", only: :dev, runtime: false}
     ]
   end
 
@@ -50,7 +56,7 @@ defmodule Bencode.Mixfile do
     [
       main: "Bencode",
       source_ref: "v#{@version}",
-      source_url: "https://github.com/gausby/bencode",
+      source_url: "https://github.com/gausby/bencode"
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,6 @@ defmodule Bencode.Mixfile do
   end
 
   defp deps do
-    [{:eqc_ex, "~> 1.3.0"},
-     {:credo, "~> 0.6.1", only: [:dev, :test]}]
+    [{:eqc_ex, "~> 1.3.0"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,16 +1,19 @@
 defmodule Bencode.Mixfile do
   use Mix.Project
 
+  @version "0.3.2"
+
   def project do
     [app: :bencode,
-     version: "0.3.2",
+     version: @version,
      elixir: "~> 1.2",
      test_pattern: "*_{test,eqc}.exs",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: description(),
      package: package(),
-     deps: deps()]
+     deps: deps(),
+     docs: docs()]
   end
 
   def application do
@@ -37,6 +40,17 @@ defmodule Bencode.Mixfile do
   end
 
   defp deps do
-    [{:eqc_ex, "~> 1.3.0"}]
+    [
+      {:eqc_ex, "~> 1.3.0"},
+      {:ex_doc, "~> 0.18.0", only: :dev, runtime: false},
+    ]
+  end
+
+  defp docs do
+    [
+      main: "Bencode",
+      source_ref: "v#{@version}",
+      source_url: "https://github.com/gausby/bencode",
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,10 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "eqc_ex": {:hex, :eqc_ex, "1.3.0", "04dc4481319d2e2ff1ce136507078cdbaf5a124d6a05ce32d5d642db28b053e4", [:mix], []}}
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "eqc_ex": {:hex, :eqc_ex, "1.3.0", "04dc4481319d2e2ff1ce136507078cdbaf5a124d6a05ce32d5d642db28b053e4", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
Hi Martin,

I tried to give the lib some love with docs & formatting.

*_eqc.exs tests are failing.
Probably the elixir version required should be bumped to 1.4. I can't compile the lib on 1.2 (maybe it's just me).

If you bump the version now in mix.exs and publish with `mix hex.publish` online hex docs will be generated, that's why I added the `@doc` attributes to the modules, they are copied & almost identical to README.

Hope this helps, cheers.