### PR TITLE
mix: Don't depend on eqc_ex in production builds

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Bencode.Mixfile do
   end
 
   defp deps do
-    [{:eqc_ex, "~> 1.3.0"},
+    [{:eqc_ex, "~> 1.3.0", only: [:dev, :test]},
      {:credo, "~> 0.6.1", only: [:dev, :test]}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Bencode.Mixfile do
   end
 
   defp deps do
-    [{:eqc_ex, "~> 1.3.0", only: [:dev, :test]},
+    [{:eqc_ex, "~> 1.3.1", only: [:dev, :test]},
      {:credo, "~> 0.6.1", only: [:dev, :test]}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "eqc_ex": {:hex, :eqc_ex, "1.3.0", "04dc4481319d2e2ff1ce136507078cdbaf5a124d6a05ce32d5d642db28b053e4", [:mix], []}}
+  "eqc_ex": {:hex, :eqc_ex, "1.3.2", "a2a01442057db92de202cca9bd81e6581b50401af741c1b0cefc99d91d73fcfc", [:mix], []}}


### PR DESCRIPTION
Fixes #7

Edit: I've also decided to add another change to this pull request to avoid merge conflicts:

Bumping the dependency for eqc to 1.3.1. I think syntax errors in the mix.exs file causes mix to not register the eqc subcommands (they don't appear in `mix help`, etc). I hope I managed to bump the version reasonably, both in mix.exs and in the lock.file, but please verify that it works for you as well. You will end up with 1.3.2, but only becuase that's the most recent version compatible with `~> 1.3.1`.